### PR TITLE
feat: Added realtime checking of status based code and impletion of the is starting service. ❤️ 🥇 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,13 @@ log = "0.4.21"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 syslog = "6.1.0"
+thiserror = "1.0.58"
 tokio = { version = "1", features = ["full"] }
+zbus = "4.1.2"
+
+[dependencies.async-std]
+version = "1.12.0"
+features = ["attributes"]
 
 [package.metadata.rpm]
 maintainer = "Anubhav Gain <iamanubhavgain@gmail.com>"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use env_logger::Env;
 use std::env;
-
 mod servicehelper;
 use servicehelper::ServiceHelper;
 
@@ -15,7 +14,11 @@ async fn main() {
     env_logger::Builder::from_env(Env::default().default_filter_or(log_level)).init();
 
     // Create an instance of ServiceHelper
-    let service_helper = ServiceHelper;
+    let mut service_helper = ServiceHelper {
+        osquery_prev_status: String::new(),
+        wazuh_prev_status: String::new(),
+        clamav_prev_status: String::new(),
+    };
 
     // Run the service check timer asynchronously
     service_helper.run_service_check_timer().await;

--- a/src/servicehelper.rs
+++ b/src/servicehelper.rs
@@ -1,58 +1,68 @@
 use std::process::Command;
 use serde_json::{json, Value};
 use log::info;
+use tokio::sync::mpsc::{self, Receiver};
 
-pub struct ServiceHelper;
+pub struct ServiceHelper {
+    // Track previous states of services
+    pub osquery_prev_status: String,
+    pub wazuh_prev_status: String,
+    pub clamav_prev_status: String,
+}
 
 impl ServiceHelper {
-    pub async fn run_service_check_timer(&self) {
-        loop {
-            // Run service checks
-            let menu_item_data = self.get_menu_item_data().await;
-            info!("{}", serde_json::to_string_pretty(&menu_item_data).unwrap());
+    pub async fn run_service_check_timer(&mut self) {
+        let (tx, mut rx): (tokio::sync::mpsc::Sender<Value>, Receiver<Value>) = mpsc::channel(100);
 
-            // Wait for 10 seconds before running the checks again
-            tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
-        }
-    }
-
-    pub async fn get_menu_item_data(&self) -> Value {
+        // Clone or copy the data needed from `self`
         let osquery_installed = self.is_osquery_installed();
-        let osquery_status = self.get_service_status("osqueryd").await;
-
         let wazuh_installed = self.is_wazuh_installed();
-        let wazuh_status = self.get_service_status("wazuh-agentd").await;
-
         let clamav_installed = self.is_clamav_installed();
-        let clamav_status = self.get_service_status("clamav-clamonacc").await;
 
-        let menu_item_data = json!({
-            "menuItems": [
-                {
-                    "text": "User Behavior Analytics",
-                    "description": format!("osquery is {}installed and {}.", 
-                                           if osquery_installed { "" } else { "not " },
-                                           osquery_status),
-                    "status": if osquery_installed && osquery_status.contains("active") { 2 } else { 0 }
-                },
-                {
-                    "text": "Endpoint Detection and Response",
-                    "description": format!("Wazuh is {}installed and {}.", 
-                                           if wazuh_installed { "" } else { "not " },
-                                           wazuh_status),
-                    "status": if wazuh_installed && wazuh_status.contains("active") { 2 } else { 0 }
-                },
-                {
-                    "text": "End-Point Protection",
-                    "description": format!("ClamAV is {}installed and {}.", 
-                                           if clamav_installed { "" } else { "not " },
-                                           clamav_status),
-                    "status": if clamav_installed && clamav_status.contains("active") { 2 } else { 0 }
+        // Spawn a separate task to run the service checks and send updates through the channel
+        tokio::spawn(async move {
+            let mut osquery_prev_status = String::new();
+            let mut wazuh_prev_status = String::new();
+            let mut clamav_prev_status = String::new();
+
+            loop {
+                // Check for changes in service status
+                let osquery_status = get_service_status("osqueryd").await;
+                let wazuh_status = get_service_status("wazuh-agentd").await;
+                let clamav_status = get_service_status("clamav-clamonacc").await;
+
+                if osquery_status != osquery_prev_status ||
+                   wazuh_status != wazuh_prev_status ||
+                   clamav_status != clamav_prev_status {
+
+                    // Update previous states
+                    osquery_prev_status = osquery_status.clone();
+                    wazuh_prev_status = wazuh_status.clone();
+                    clamav_prev_status = clamav_status.clone();
+
+                    // Send updated menu item data through the channel
+                    let menu_item_data = get_menu_item_data(
+                        osquery_installed,
+                        wazuh_installed,
+                        clamav_installed,
+                        osquery_status,
+                        wazuh_status,
+                        clamav_status,
+                    ).await;
+
+                    if let Err(e) = tx.send(menu_item_data).await {
+                        eprintln!("Error sending update through channel: {}", e);
+                    }
                 }
-            ]
+
+                // No explicit sleep here
+            }
         });
 
-        menu_item_data
+        // Listen for updates from the channel and print them
+        while let Some(update) = rx.recv().await {
+            info!("{}", serde_json::to_string_pretty(&update).unwrap());
+        }
     }
 
     fn is_osquery_installed(&self) -> bool {
@@ -60,25 +70,8 @@ impl ServiceHelper {
         osquery_paths.iter().all(|&path| std::path::Path::new(path).exists())
     }
 
-    async fn get_service_status(&self, service: &str) -> String {
-        let output = Command::new("systemctl")
-            .arg("is-active")
-            .arg(service)
-            .output()
-            .expect("Failed to execute command");
-    
-        let status = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    
-        match status.as_str() {
-            "active" => "running".to_string(),
-            "inactive" => "halted".to_string(),
-            "activating" | "deactivating" | "failed" | _ => "stopped".to_string(),
-        }
-    }
-
     fn is_wazuh_installed(&self) -> bool {
         let required_files = ["agent-auth", "manage_agents", "wazuh-agentd", "wazuh-control", "wazuh-execd", "wazuh-logcollector", "wazuh-modulesd", "wazuh-syscheckd"];
-    
         required_files.iter().all(|&file| std::path::Path::new("/var/ossec/bin/").join(file).exists())
     }
 
@@ -92,4 +85,48 @@ impl ServiceHelper {
     }
 }
 
+pub async fn get_menu_item_data(osquery_installed: bool, wazuh_installed: bool, clamav_installed: bool, osquery_status: String, wazuh_status: String, clamav_status: String) -> Value {
+    let menu_item_data = json!({
+        "menuItems": [
+            {
+                "text": "User Behavior Analytics",
+                "description": format!("osquery is {}installed and {}.",
+                                       if osquery_installed { "" } else { "not " },
+                                       osquery_status),
+                "status": if osquery_installed && osquery_status.contains("active") { 2 } else { 0 }
+            },
+            {
+                "text": "Endpoint Detection and Response",
+                "description": format!("Wazuh is {}installed and {}.",
+                                       if wazuh_installed { "" } else { "not " },
+                                       wazuh_status),
+                "status": if wazuh_installed && wazuh_status.contains("active") { 2 } else { 0 }
+            },
+            {
+                "text": "End-Point Protection",
+                "description": format!("ClamAV is {}installed and {}.",
+                                       if clamav_installed { "" } else { "not " },
+                                       clamav_status),
+                "status": if clamav_installed && clamav_status.contains("active") { 2 } else { 0 }
+            }
+        ]
+    });
 
+    menu_item_data
+}
+
+async fn get_service_status(service: &str) -> String {
+    let output = Command::new("systemctl")
+        .arg("is-active")
+        .arg(service)
+        .output()
+        .expect("Failed to execute command");
+
+    let status = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    match status.as_str() {
+        "active" => "running".to_string(),
+        "inactive" => "halted".to_string(),
+        "activating" | "deactivating" | "failed" | _ => "stopped".to_string(),
+    }
+}


### PR DESCRIPTION
Here's a summary of the changes i have made:

1. Updated the `run_service_check_timer` method in the `ServiceHelper` struct to resolve the borrowing issue by using move semantics instead of cloning `self`.
2. Removed the attempt to clone `self` within the `run_service_check_timer` method.
3. Modified the closure inside `tokio::spawn` to capture the previous status variables directly.
4. Updated the `ServiceHelper` struct to remove the `Clone` trait requirement and improve efficiency by using move semantics.
